### PR TITLE
Add alt editor and roster filters

### DIFF
--- a/QDKP2_GUI/Code/AltEditor.lua
+++ b/QDKP2_GUI/Code/AltEditor.lua
@@ -1,0 +1,51 @@
+local AltEditor = {}
+
+function AltEditor:OnLoad(frame)
+  self.Frame = frame
+  self.ListFrame = QDKP2_frame6_List
+  self.Lines = {}
+  for i=1,10 do
+    local fs = self.Frame:CreateFontString("QDKP2_frame6_line"..i,"OVERLAY","GameFontHighlightSmall")
+    fs:SetPoint("TOPLEFT", self.ListFrame, "TOPLEFT", 0, -(i-1)*14)
+    fs:SetText("")
+    self.Lines[i] = fs
+  end
+  QDKP2GUI_AltEditor = self
+end
+
+function AltEditor:Hide()
+  self.Frame:Hide()
+end
+
+function AltEditor:ShowPlayer(name)
+  self.Player = name
+  self:Refresh()
+  self.Frame:Show()
+end
+
+function AltEditor:Refresh()
+  if not self.Frame:IsVisible() then return end
+  for i=1,#self.Lines do
+    self.Lines[i]:SetText("")
+  end
+  if not self.Player then return end
+  local idx = 1
+  for alt,main in pairs(QDKP2alts) do
+    if main == self.Player then
+      self.Lines[idx]:SetText(alt)
+      idx = idx + 1
+      if idx > #self.Lines then break end
+    end
+  end
+  self.Frame:SetTitle("Alts of "..self.Player)
+end
+
+function AltEditor:AddAlt()
+  local alt = QDKP2_frame6_Search:GetText()
+  if not alt or alt == "" or not self.Player then return end
+  QDKP2_MakeAlt(alt, self.Player)
+  QDKP2_frame6_Search:SetText("")
+  self:Refresh()
+end
+
+return AltEditor

--- a/QDKP2_GUI/Code/Roster.lua
+++ b/QDKP2_GUI/Code/Roster.lua
@@ -305,13 +305,32 @@ function myClass.PupulateList(self)
 		self.List=temp
 	end
   if QDKP2GUI_HideOffline and self.Sel == 'guild' then
-		local temp={}
-		for i,name in pairs(self.List) do
-			if QDKP2online[name] and  not QDKP2_IsExternal(name) then table.insert(temp,name); end
-		end
-		self.List=temp
+                local temp={}
+                for i,name in pairs(self.List) do
+                        if QDKP2online[name] and  not QDKP2_IsExternal(name) then table.insert(temp,name); end
+                end
+                self.List=temp
   end
+  self:ApplyFilters()
   QDKP2_Debug(2, "GUI-Roster","List populated. Voices="..tostring(#self.List))
+end
+
+function myClass.ApplyFilters(self)
+  local nf = string.lower(QDKP2_frame2_SearchName:GetText() or "")
+  local cf = string.lower(QDKP2_frame2_SearchClass:GetText() or "")
+  local rf = string.lower(QDKP2_frame2_SearchRank:GetText() or "")
+  if nf=="" and cf=="" and rf=="" then return end
+  local out={}
+  for _,name in ipairs(self.List) do
+    local add=true
+    if nf~="" and not string.find(string.lower(name), nf, 1, true) then add=false end
+    local cls=string.lower(QDKP2class[name] or "")
+    if cf~="" and not string.find(cls, cf, 1, true) then add=false end
+    local rnk=string.lower(tostring(QDKP2rank[name] or ""))
+    if rf~="" and not string.find(rnk, rf, 1, true) then add=false end
+    if add then table.insert(out,name); end
+  end
+  self.List=out
 end
 
 
@@ -672,6 +691,11 @@ AltMake={text="Make alt",func=function()
   end
 end
 },
+AltEdit={text="Edit Alts",func=function()
+  if #myClass.SelectedPlayers==1 then
+    QDKP2GUI_AltEditor:ShowPlayer(myClass.SelectedPlayers[1])
+  end
+end},
 ExternalAdd={text="Add External",
 func=function()
   QDKP2_NewExternal()
@@ -882,6 +906,7 @@ function myClass.PlayerMenu(self,List)
     if QDKP2_IsAlt(name) then table.insert(menu,2,LogVoices.AltClear)
     else table.insert(menu,2,LogVoices.AltMake)
     end
+    table.insert(menu,3,LogVoices.AltEdit)
     if managing and (QDKP2_IsStandby(name) or not QDKP2_IsInRaid(name)) then
       table.insert(menu,2,LogVoices.StandbyAdd)
     end

--- a/QDKP2_GUI/QDKP2_GUI.toc
+++ b/QDKP2_GUI/QDKP2_GUI.toc
@@ -16,6 +16,7 @@ Code\minimap_button.lua
 Code\Misc.lua
 Code\Roster.lua
 Code\ToolBox.lua
+Code\AltEditor.lua
 Code\Init.lua
 code\LogEntryMod.lua
 

--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -1498,6 +1498,41 @@
         </OnClick>
       </Scripts>
     </CheckButton>
+
+    <!-- Filters -->
+    <EditBox name="QDKP2_frame2_SearchName" inherits="InputBoxTemplate">
+      <Size><AbsDimension x="90" y="20"/></Size>
+      <Anchors>
+        <Anchor point="BOTTOMLEFT">
+          <Offset><AbsDimension x="20" y="40"/></Offset>
+        </Anchor>
+      </Anchors>
+      <Scripts>
+        <OnTextChanged>QDKP2GUI_Roster:Refresh(true)</OnTextChanged>
+      </Scripts>
+    </EditBox>
+    <EditBox name="QDKP2_frame2_SearchClass" inherits="InputBoxTemplate">
+      <Size><AbsDimension x="70" y="20"/></Size>
+      <Anchors>
+        <Anchor point="LEFT" relativeTo="QDKP2_frame2_SearchName" relativePoint="RIGHT">
+          <Offset><AbsDimension x="5" y="0"/></Offset>
+        </Anchor>
+      </Anchors>
+      <Scripts>
+        <OnTextChanged>QDKP2GUI_Roster:Refresh(true)</OnTextChanged>
+      </Scripts>
+    </EditBox>
+    <EditBox name="QDKP2_frame2_SearchRank" inherits="InputBoxTemplate">
+      <Size><AbsDimension x="70" y="20"/></Size>
+      <Anchors>
+        <Anchor point="LEFT" relativeTo="QDKP2_frame2_SearchClass" relativePoint="RIGHT">
+          <Offset><AbsDimension x="5" y="0"/></Offset>
+        </Anchor>
+      </Anchors>
+      <Scripts>
+        <OnTextChanged>QDKP2GUI_Roster:Refresh(true)</OnTextChanged>
+      </Scripts>
+    </EditBox>
 -->
 
       <EditBox name="QDKP2_Frame2_Bid_Item" inherits="InputBoxTemplate">
@@ -2857,6 +2892,33 @@
         QDKP2_modify_log_entry_linkText2:SetTextColor(1, 1, 1)
       </OnLoad>
     </Scripts>
+  </Frame>
+
+  <Frame name="QDKP2_Frame6" inherits="QDKP2DialogTitled">
+    <Size><AbsDimension x="220" y="160"/></Size>
+    <Anchors>
+      <Anchor point="CENTER" />
+    </Anchors>
+    <Frames>
+      <Button name="$parent_Close" inherits="UIPanelCloseButton">
+        <Anchors><Anchor point="TOPRIGHT"><Offset><AbsDimension x="-4" y="-4"/></Offset></Anchor></Anchors>
+        <Scripts><OnClick>QDKP2GUI_AltEditor:Hide()</OnClick></Scripts>
+      </Button>
+      <Frame name="QDKP2_frame6_List">
+        <Anchors><Anchor point="TOPLEFT"><Offset><AbsDimension x="20" y="-30"/></Offset></Anchor></Anchors>
+      </Frame>
+      <EditBox name="QDKP2_frame6_Search" inherits="InputBoxTemplate">
+        <Size><AbsDimension x="110" y="20"/></Size>
+        <Anchors><Anchor point="BOTTOMLEFT"><Offset><AbsDimension x="20" y="20"/></Offset></Anchor></Anchors>
+        <Scripts><OnEnterPressed>QDKP2GUI_AltEditor:AddAlt()</OnEnterPressed></Scripts>
+      </EditBox>
+      <Button name="QDKP2_frame6_Add" inherits="UIPanelButtonTemplate" text="Add">
+        <Size><AbsDimension x="50" y="20"/></Size>
+        <Anchors><Anchor point="LEFT" relativeTo="QDKP2_frame6_Search" relativePoint="RIGHT"><Offset><AbsDimension x="5" y="0"/></Offset></Anchor></Anchors>
+        <Scripts><OnClick>QDKP2GUI_AltEditor:AddAlt()</OnClick></Scripts>
+      </Button>
+    </Frames>
+    <Scripts><OnLoad>QDKP2GUI_AltEditor:OnLoad(self)</OnLoad></Scripts>
   </Frame>
 </Ui>
 


### PR DESCRIPTION
## Summary
- add an AltEditor frame for managing alts via UI
- include new code file in TOC
- add search filter boxes to the roster
- integrate alt editor from the roster menu
- apply roster filtering based on name, class, and rank

## Testing
- `luac -p QDKP2_GUI/Code/AltEditor.lua`
- `luac -p QDKP2_GUI/Code/Roster.lua`
- `apt-get update`
- `apt-get install -y lua5.1`

------
https://chatgpt.com/codex/tasks/task_b_6875afc4b5a48324bb7ba20352b9e024