### PR TITLE
Fix alt clearing message

### DIFF
--- a/QDKP_V2/Code/Core/Alts.lua
+++ b/QDKP_V2/Code/Core/Alts.lua
@@ -37,7 +37,7 @@ function QDKP2_MakeAlt(alt,main,sure)
   end
   if not main then
     QDKP2_Debug(2,"Core","Clearing alt relation for "..alt)
-    if not QDKP2_IsAlt(alt) then QDKP2_Msg(name.." is not an alt."); return; end
+    if not QDKP2_IsAlt(alt) then QDKP2_Msg(alt.." is not an alt."); return; end
     QDKP2altsRestore[alt]=""
 
     --QDKP2alts[alt]=nil


### PR DESCRIPTION
## Summary
- fix alt clearing message by referencing the alt name instead of an undefined variable

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_6875af3d5fb48324bd2243abde1b7c22