### PR TITLE
Fix constants path

### DIFF
--- a/QDKP_V2/Code/Core/Initialization.lua
+++ b/QDKP_V2/Code/Core/Initialization.lua
@@ -4,7 +4,7 @@
 --             ## CORE FUNCTIONS ##
 --               Initializators
 --
--- Here I have all the functions called when QDKP starts, Including Costants and variables initializators.
+-- Here I have all the functions called when QDKP starts, Including Constants and variables initializators.
 --
 -- API Documentation:
 -- QDKP2_InitData(Guild): Reset only unsaved data if called without arguments. Reset <Guild>'s data if provided, and resets all if <Guild> is "*_ALL_*". Guild is moreline "Realm-Guild"

--- a/QDKP_V2/Code/Logging/Constants.lua
+++ b/QDKP_V2/Code/Logging/Constants.lua
@@ -2,7 +2,7 @@
 -- This file is a part of QDKP_V2 (see about.txt in the Addon's root folder)
 
 --             ## LOGGING SYSTEM ##
---                   Costants
+--                   Constants
 
 --Log Types
 QDKP2LOG_EVENT = 1          --generic log event

--- a/QDKP_V2/QDKP_V2.toc
+++ b/QDKP_V2/QDKP_V2.toc
@@ -24,7 +24,6 @@ Code\Lib\Deformat-2.0.lua
 Code\Lib\LibRSA-1.0.lua
 
 Code\DefaultOptions.lua
-Code\Core\Costants.lua
 Code\Core\DKP_Editing.lua
 Code\Core\DKP_Management.lua
 Code\Core\Events.lua
@@ -45,7 +44,7 @@ Code\Core\Crypto.lua
 Local\enGB.lua
 Local\frFR.lua
 
-Code\Logging\Costants.lua
+Code\Logging\Constants.lua
 Code\Logging\LogEntry.lua
 Code\Logging\DB.lua
 Code\Logging\Logging.lua


### PR DESCRIPTION
## Summary
- rename `Costants.lua` to `Constants.lua`
- update `.toc` paths and remove invalid line
- fix comment typos referencing "Costants"

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_b_6875b206a1cc83248b6770809c091609