### PR TITLE
Set interface version for WotLK

### DIFF
--- a/QDKP2_Config/QDKP2_Config.toc
+++ b/QDKP2_Config/QDKP2_Config.toc
@@ -1,4 +1,4 @@
-## Interface: 40000
+## Interface: 30300
 ## Title: Quick DKP V2 - Config
 ## Author: rb@belloli.net
 ## Version: 2.7.2

--- a/QDKP2_GUI/QDKP2_GUI.toc
+++ b/QDKP2_GUI/QDKP2_GUI.toc
@@ -1,4 +1,4 @@
-## Interface: 40000
+## Interface: 30300
 ## Title: Quick DKP V2 - GUI
 ## Author: jay_2uk@quickdkp.com
 ## Version: 2.7.5

--- a/QDKP_V2/QDKP_V2.toc
+++ b/QDKP_V2/QDKP_V2.toc
@@ -1,4 +1,4 @@
-## Interface: 40000
+## Interface: 30300
 ## Title: Quick DKP V2 - Core
 ## Author: Jamie Hirst (jay_2uk@quickdkp.com)
 ## Version: 2.7.5


### PR DESCRIPTION
## Summary
- target WotLK 3.3.5 by setting `## Interface: 30300` for all modules

## Testing
- `grep -R "GetSpecialization" -n | head`
- `grep -R "C_Pet" -n | head`
- `grep -R "GetCurrencyInfo" -n | head`


------
https://chatgpt.com/codex/tasks/task_b_6875ba1137a4832491531bb54dc366ae