### PR TITLE
Fix GUI not loading when LibDataBroker missing

### DIFF
--- a/QDKP2_GUI/Code/Init.lua
+++ b/QDKP2_GUI/Code/Init.lua
@@ -52,19 +52,20 @@ function QDKP2_ChatEdit_InsertLink(...)
 end
 
 --RAZ101019_START 
--- Basic LDB support 
-local ldb = LibStub("LibDataBroker-1.1") 
-local launcher = ldb:NewDataObject( "QDKP", { 
-type = "data source", 
-text = "QuickDKP Launcher V2", 
-icon = "Interface\\Addons\\QDKP2_GUI\\Arts\\LogoSmall.tga", 
-OnLeave = Block_OnLeave, 
-OnClick = function(self, button) 
-if button == "LeftButton" then 
-QDKP2_Toggle_Main() 
-elseif button == "RightButton" then 
-QDKP2GUI_Roster:Toggle() 
-end 
-end, 
-} ) 
+local ldb = LibStub:GetLibrary("LibDataBroker-1.1", true)
+if ldb then
+  ldb:NewDataObject("QDKP", {
+  type = "data source",
+  text = "QuickDKP Launcher V2",
+  icon = "Interface\\Addons\\QDKP2_GUI\\Arts\\LogoSmall.tga",
+  OnLeave = Block_OnLeave,
+  OnClick = function(self, button)
+  if button == "LeftButton" then
+  QDKP2_Toggle_Main()
+  elseif button == "RightButton" then
+  QDKP2GUI_Roster:Toggle()
+  end
+  end,
+  } )
+end
 --RAZ101019_END 

--- a/QDKP2_GUI/QDKP2_GUI.toc
+++ b/QDKP2_GUI/QDKP2_GUI.toc
@@ -10,14 +10,14 @@
 
 Code\GUI.lua
 Code\Log.lua
-Code\Log.Player.Lua
-Code\main.lua
-Code\minimap_button.lua
+Code\Log.Player.lua
+Code\Main.lua
+Code\Minimap_button.lua
 Code\Misc.lua
 Code\Roster.lua
 Code\ToolBox.lua
 Code\AltEditor.lua
 Code\Init.lua
-code\LogEntryMod.lua
+Code\LogEntryMod.lua
 
 QDKP2_GUI.xml


### PR DESCRIPTION
## Summary
- load LibDataBroker only if it exists
- fix case mismatches in `QDKP2_GUI.toc`

## Testing
- `luac -p QDKP2_GUI/Code/Init.lua`

------
https://chatgpt.com/codex/tasks/task_b_687608b18bc48324a1fac758117d7523