### PR TITLE
Add debug messages for GUI loading

### DIFF
--- a/QDKP2_GUI/Code/AltEditor.lua
+++ b/QDKP2_GUI/Code/AltEditor.lua
@@ -1,3 +1,4 @@
+print("AltEditor.lua: File loaded.")
 local AltEditor = {}
 
 function AltEditor:OnLoad(frame)

--- a/QDKP2_GUI/Code/Init.lua
+++ b/QDKP2_GUI/Code/Init.lua
@@ -1,5 +1,6 @@
 ------------------------------------- INIT ----------------------------------
 function QDKP2GUI_Init()
+  print("Init.lua: QDKP2GUI_Init() started.")
   QDKP2_Events:RegisterCallback("TIMERBASE_UPDATED",function(...) QDKP2GUI_Main:TimerCountdownRefresh(...); end)
   QDKP2_Events:RegisterCallback("DATA_UPDATED",QDKP2GUI_UpdateManager)
   QDKP2_Events:RegisterCallback("TIMER_START",function(...) QDKP2GUI_Main:Refresh(); end)
@@ -19,6 +20,7 @@ function QDKP2GUI_Init()
   QDKP2_Events:RegisterCallback("BID_CLOSE",function(...) QDKP2GUI_Roster:Refresh(); end)
   QDKP2_Events:RegisterCallback("BID_CANCEL",function(...) QDKP2GUI_Roster:Refresh(); end)
   QDKP2_Events:RegisterCallback("LOAD",QDKP2GUI_OnLoad)
+  print("Init.lua: QDKP2GUI_Init() finished.")
 end
 
 ------------------------------------- ON LOAD ----------------------------------------

--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -9,13 +9,16 @@
   <Frame name="QDKP2GUI">
     <Scripts>
       <OnLoad>
+        print("QDKP2_GUI.xml: OnLoad started.")
         tinsert(UISpecialFrames,"QDKP2_Frame1");
         tinsert(UISpecialFrames,"QDKP2_Frame2");
         tinsert(UISpecialFrames,"QDKP2_Frame3");
         tinsert(UISpecialFrames,"QDKP2_Frame4");
         tinsert(UISpecialFrames,"QDKP2_Frame5");
         tinsert(UISpecialFrames,"QDKP2_Frame6");
+        print("QDKP2_GUI.xml: UISpecialFrames registered.")
         QDKP2GUI_Init();
+        print("QDKP2_GUI.xml: OnLoad finished.")
       </OnLoad>
     </Scripts>
   </Frame>


### PR DESCRIPTION
## Summary
- log when AltEditor loads
- trace the start and end of `QDKP2GUI_Init`
- trace GUI OnLoad to confirm frame registration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687667741310832483f37b275dd3eb36