### PR TITLE
Fix script load order in GUI

### DIFF
--- a/QDKP2_GUI/QDKP2_GUI.xml
+++ b/QDKP2_GUI/QDKP2_GUI.xml
@@ -6,6 +6,17 @@
 -->
 <Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
 
+  <Script file="Code\Init.lua"/>
+  <Script file="Code\Main.lua"/>
+  <Script file="Code\GUI.lua"/>
+  <Script file="Code\Roster.lua"/>
+  <Script file="Code\Log.lua"/>
+  <Script file="Code\Log.Player.lua"/>
+  <Script file="Code\LogEntryMod.lua"/>
+  <Script file="Code\ToolBox.lua"/>
+  <Script file="Code\Minimap_button.lua"/>
+  <Script file="Code\AltEditor.lua"/>
+
   <Frame name="QDKP2GUI">
     <Scripts>
       <OnLoad>


### PR DESCRIPTION
## Summary
- load GUI lua files in order to ensure AltEditor is last

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68768027c83c83249cb04840eb6c1064